### PR TITLE
fix intro background not covering full screen on safari

### DIFF
--- a/source/_sass/base/_intro.scss
+++ b/source/_sass/base/_intro.scss
@@ -3,7 +3,8 @@ body.home-intro {
   display: table;
 
   .intro {
-    display: table-cell;
+    display: flex;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
Added display flex to the .intro div to have full coverage on Safari.